### PR TITLE
Adding to DTOs

### DIFF
--- a/src/main/java/com/damienwesterman/defensedrill/rest_api/service/AbstractCategoryService.java
+++ b/src/main/java/com/damienwesterman/defensedrill/rest_api/service/AbstractCategoryService.java
@@ -101,10 +101,12 @@ public abstract class AbstractCategoryService<E extends AbstractCategoryEntity, 
     public List<E> findAll(@NonNull List<Long> ids) {
         List<E> ret = repo.findAllById(ids);
         /*
-         * This is okay to do here because drills the list being returned should always be
-         * <25 (and this is generous), so overhead should be insignificant.y
+         * This is okay to do here because the list being returned should always be
+         * <25 (and this is generous), so overhead should be insignificant.
          */
-        ret.sort((arg0, arg1) -> arg0.getName().compareToIgnoreCase(arg1.getName()));
+        ret.sort(
+            (category1, category2) -> category1.getName().compareToIgnoreCase(category2.getName())
+        );
         return ret;
     }
 

--- a/src/main/java/com/damienwesterman/defensedrill/rest_api/service/DrillService.java
+++ b/src/main/java/com/damienwesterman/defensedrill/rest_api/service/DrillService.java
@@ -131,6 +131,26 @@ public class DrillService {
     }
 
     /**
+     * Return all entities in the database that are in the list of IDs sorted
+     * alphabetically by name.
+     *
+     * @param ids List of Drill IDs.
+     * @return List of Drill objects.
+     */
+    @NonNull
+    public List<DrillEntity> findAll(List<Long> ids) {
+        List<DrillEntity> ret = repo.findAllById(ids);
+        /*
+         * This is okay to do here because the list being returned should always be
+         * <25 (and this is generous), so overhead should be insignificant.
+         */
+        ret.sort(
+            (drill1, drill2) -> drill1.getName().compareToIgnoreCase(drill2.getName())
+        );
+        return ret;
+    }
+
+    /**
      * Delete an entity from the database by its ID - if it exists.
      *
      * @param id ID of the AbstractCategoryEntity.

--- a/src/main/java/com/damienwesterman/defensedrill/rest_api/web/DrillController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/rest_api/web/DrillController.java
@@ -27,8 +27,11 @@
 package com.damienwesterman.defensedrill.rest_api.web;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
@@ -48,6 +51,7 @@ import com.damienwesterman.defensedrill.rest_api.service.CategorySerivce;
 import com.damienwesterman.defensedrill.rest_api.service.DrillService;
 import com.damienwesterman.defensedrill.rest_api.service.SubCategorySerivce;
 import com.damienwesterman.defensedrill.rest_api.web.dto.DrillCreateDTO;
+import com.damienwesterman.defensedrill.rest_api.web.dto.DrillRelatedDTO;
 import com.damienwesterman.defensedrill.rest_api.web.dto.DrillResponseDTO;
 import com.damienwesterman.defensedrill.rest_api.web.dto.DrillUpdateDTO;
 import com.damienwesterman.defensedrill.rest_api.web.dto.ErrorMessageDTO;
@@ -59,6 +63,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -101,9 +106,28 @@ public class DrillController {
             return ResponseEntity.noContent().build();
         }
 
+        // Map of Drills by their ID for quick lookup
+        Map<Long, DrillEntity> drillMap = drills.stream()
+            .collect(Collectors.toMap(DrillEntity::getId, Function.identity()));
+
         return ResponseEntity.ok(
             drills.stream()
-                .map(DrillResponseDTO::new)
+                .map(drill -> {
+                    List<DrillEntity> relatedDrills;
+                    if (null == drill.getRelatedDrills()) {
+                        relatedDrills = new ArrayList<>(0);
+                    } else {
+                        relatedDrills = new ArrayList<>(drill.getRelatedDrills().size());
+                        System.out.println(drill.getRelatedDrills());
+                        relatedDrills = drill.getRelatedDrills().stream()
+                            .map(id -> {
+                                System.out.println(id);
+                                return drillMap.get(id);
+                            })
+                            .collect(Collectors.toList());
+                    }
+                    return new DrillResponseDTO(drill, relatedDrills);
+                })
                 .collect(Collectors.toList())
         );
     }
@@ -153,9 +177,13 @@ public class DrillController {
             content = @Content(/* No Content */))
     })
     @GetMapping("/name/{name}")
+    @Transactional
     public ResponseEntity<DrillResponseDTO> getDrillByName(@PathVariable String name) {
         return drillService.find(name)
-                    .map(foundDrill -> ResponseEntity.ok(new DrillResponseDTO(foundDrill)))
+                    .map(foundDrill ->
+                        ResponseEntity.ok(new DrillResponseDTO(
+                            foundDrill,
+                            drillService.findAll(foundDrill.getRelatedDrills()))))
                     .orElse(ResponseEntity.notFound().build());
     }
 
@@ -177,7 +205,10 @@ public class DrillController {
     @GetMapping("/id/{id}")
     public ResponseEntity<DrillResponseDTO> getDrillById(@PathVariable Long id) {
         return drillService.find(id)
-                    .map(foundDrill -> ResponseEntity.ok(new DrillResponseDTO(foundDrill)))
+                    .map(foundDrill ->
+                        ResponseEntity.ok(new DrillResponseDTO(
+                            foundDrill,
+                            drillService.findAll(foundDrill.getRelatedDrills()))))
                     .orElse(ResponseEntity.notFound().build());
     }
 
@@ -234,7 +265,11 @@ public class DrillController {
 
         DrillEntity updatedDrill = drillService.save(drillToUpdate);
 
-        return ResponseEntity.ok(new DrillResponseDTO(updatedDrill));
+        return ResponseEntity.ok(
+            new DrillResponseDTO(
+                updatedDrill,
+                drillService.findAll(updatedDrill.getRelatedDrills())
+            ));
     }
 
     /**

--- a/src/main/java/com/damienwesterman/defensedrill/rest_api/web/DrillController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/rest_api/web/DrillController.java
@@ -51,7 +51,6 @@ import com.damienwesterman.defensedrill.rest_api.service.CategorySerivce;
 import com.damienwesterman.defensedrill.rest_api.service.DrillService;
 import com.damienwesterman.defensedrill.rest_api.service.SubCategorySerivce;
 import com.damienwesterman.defensedrill.rest_api.web.dto.DrillCreateDTO;
-import com.damienwesterman.defensedrill.rest_api.web.dto.DrillRelatedDTO;
 import com.damienwesterman.defensedrill.rest_api.web.dto.DrillResponseDTO;
 import com.damienwesterman.defensedrill.rest_api.web.dto.DrillUpdateDTO;
 import com.damienwesterman.defensedrill.rest_api.web.dto.ErrorMessageDTO;
@@ -114,6 +113,11 @@ public class DrillController {
             drills.stream()
                 .map(drill -> {
                     List<DrillEntity> relatedDrills;
+
+                    /*
+                    * Compiler is generating a warning for each call to drill.getRelatedDrills().
+                    * We can safely ignore this because of this first null check here.
+                    */
                     if (null == drill.getRelatedDrills()) {
                         relatedDrills = new ArrayList<>(0);
                     } else {

--- a/src/main/java/com/damienwesterman/defensedrill/rest_api/web/dto/DrillRelatedDTO.java
+++ b/src/main/java/com/damienwesterman/defensedrill/rest_api/web/dto/DrillRelatedDTO.java
@@ -1,0 +1,77 @@
+/****************************\
+ *      ________________      *
+ *     /  _             \     *
+ *     \   \ |\   _  \  /     *
+ *      \  / | \ / \  \/      *
+ *      /  \ | / | /  /\      *
+ *     /  _/ |/  \__ /  \     *
+ *     \________________/     *
+ *                            *
+ \****************************/
+/*
+ * Copyright 2024 Damien Westerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.damienwesterman.defensedrill.rest_api.web.dto;
+
+import org.springframework.lang.NonNull;
+
+import com.damienwesterman.defensedrill.rest_api.entity.DrillEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO for related drills of {@link DrillEntity} types.
+ * <br><br>
+ * This DTO should only be outbound, <b><i>NEVER</b></i> inbound requests as it contains no
+ * input validation.
+ * <br><br>
+ * NOTE: Any changes here must also be reflected in the MVC repo.
+ */
+@Schema(
+    name = "RelatedDrill",
+    description = "Name and ID of a related Drill."
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrillRelatedDTO {
+    @Schema(
+        description = "Database generated ID.",
+        example = "12345"
+    )
+    private Long id;
+
+    @Schema(
+        description = "Name of the Drill.",
+        example = "Round Kick"
+    )
+    private String name;
+
+    /**
+     * Parameterized constructor using a DrillEntity object.
+     *
+     * @param drill DrillEntity object to represent in a DTO.
+     */
+    public DrillRelatedDTO(@NonNull DrillEntity drill) {
+        this.id = drill.getId();
+        this.name = drill.getName();
+    }
+}

--- a/src/main/java/com/damienwesterman/defensedrill/rest_api/web/dto/DrillResponseDTO.java
+++ b/src/main/java/com/damienwesterman/defensedrill/rest_api/web/dto/DrillResponseDTO.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 import com.damienwesterman.defensedrill.rest_api.entity.CategoryEntity;
 import com.damienwesterman.defensedrill.rest_api.entity.DrillEntity;
@@ -73,25 +74,21 @@ public class DrillResponseDTO {
     private String name;
 
     @Schema(
-        description = "List of Category IDs the Drill belongs to.",
-        example = "[1,2,3,4,5]"
+        description = "List of Category IDs the Drill belongs to."
     )
-    @JsonProperty("categories")
-    private List<Long> categoryIds;
+    private List<CategoryEntity> categories;
 
     @Schema(
-        description = "List of SubCategory IDs the Drill belongs to.",
-        example = "[1,2,3,4,5]"
+        description = "List of SubCategory IDs the Drill belongs to."
     )
     @JsonProperty("sub_categories")
-    private List<Long> subCategoryIds;
+    private List<SubCategoryEntity> subCategories;
 
     @Schema(
-        description = "List of Drill IDs this Drill mentions.",
-        example = "[6,7,8,9,0]"
+        description = "List of Drill IDs this Drill mentions."
     )
     @JsonProperty("related_drills")
-    private List<Long> relatedDrillIds;
+    private List<DrillRelatedDTO> relatedDrills;
 
     @Schema(
         description = "List of Instructional how-tos to perform this Drill."
@@ -104,26 +101,38 @@ public class DrillResponseDTO {
      * @param drill DrillEntity object to represent in a DTO.
      */
     public DrillResponseDTO(@NonNull DrillEntity drill) {
+        this(drill, null);
+    }
+
+    /**
+     * Parameterized constructor using a DrillEntity object.
+     *
+     * @param drill DrillEntity object to represent in a DTO.
+     * @param relatedDrills List of related Drills.
+     */
+    public DrillResponseDTO(@NonNull DrillEntity drill, @Nullable List<DrillEntity> relatedDrills) {
         this.id = drill.getId();
         this.name = drill.getName();
 
         if (null == drill.getCategories()) {
-            this.categoryIds = new ArrayList<>();
+            this.categories = new ArrayList<>();
         } else {
-            this.categoryIds = drill.getCategories().stream()
-                                    .map(CategoryEntity::getId)
-                                    .collect(Collectors.toList());
+            this.categories = drill.getCategories();
         }
 
         if (null == drill.getSubCategories()) {
-            this.subCategoryIds = new ArrayList<>();
+            this.subCategories = new ArrayList<>();
         } else {
-            this.subCategoryIds = drill.getSubCategories().stream()
-                                    .map(SubCategoryEntity::getId)
-                                    .collect(Collectors.toList());
+            this.subCategories = drill.getSubCategories();
         }
 
-        this.relatedDrillIds = drill.getRelatedDrills();
+        if (null == relatedDrills) {
+            this.relatedDrills = new ArrayList<>();
+        } else {
+            this.relatedDrills = relatedDrills.stream()
+                                    .map(DrillRelatedDTO::new)
+                                    .collect(Collectors.toList());
+        }
 
         if (null == drill.getInstructions()) {
             this.instructions = new ArrayList<>();

--- a/src/test/java/com/damienwesterman/defensedrill/rest_api/endToEnd/EndToEndTest.java
+++ b/src/test/java/com/damienwesterman/defensedrill/rest_api/endToEnd/EndToEndTest.java
@@ -337,7 +337,7 @@ public class EndToEndTest {
             );
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(0, response.getBody().getCategoryIds().size());
+        assertEquals(0, response.getBody().getCategories().size());
     }
 
     @Test

--- a/src/test/java/com/damienwesterman/defensedrill/rest_api/integration/DrillControllerTest.java
+++ b/src/test/java/com/damienwesterman/defensedrill/rest_api/integration/DrillControllerTest.java
@@ -81,6 +81,7 @@ public class DrillControllerTest {
     SubCategorySerivce subCategorySerivce;
 
     DrillEntity drill1;
+    DrillEntity relatedDrill;
     CategoryEntity category1;
     SubCategoryEntity subCategory1;
     InstructionsEntity instructions1;
@@ -92,6 +93,7 @@ public class DrillControllerTest {
     final Long NUMBER_1 = 0L;
     final Long RELATED_DRILL_ID = 2L;
     final String DRILL_NAME_1 = "Drill Name 1";
+    final String RELATED_DRILL_NAME = "Related Drill";
     final String CATEGORY_NAME_1 = "Category Name 1";
     final String SUB_CATEGORY_NAME_1 = "Sub-Category Name 1";
     final String CATEGORY_DESCRIPTION_1 = "Category Description 1";
@@ -108,6 +110,14 @@ public class DrillControllerTest {
         drill1 = DrillEntity.builder()
                             .id(DRILL_ID_1)
                             .name(DRILL_NAME_1)
+                            .categories(new ArrayList<>())
+                            .subCategories(new ArrayList<>())
+                            .instructions(new ArrayList<>())
+                            .relatedDrills(new ArrayList<>())
+                            .build();
+        relatedDrill = DrillEntity.builder()
+                            .id(RELATED_DRILL_ID)
+                            .name(RELATED_DRILL_NAME)
                             .categories(new ArrayList<>())
                             .subCategories(new ArrayList<>())
                             .instructions(new ArrayList<>())
@@ -149,31 +159,29 @@ public class DrillControllerTest {
         drill1.getSubCategories().add(subCategory1);
         drill1.getRelatedDrills().add(RELATED_DRILL_ID);
         drill1.getInstructions().add(instructions1);
-        when(drillService.findAll()).thenReturn(List.of(drill1));
+        when(drillService.findAll()).thenReturn(List.of(drill1, relatedDrill));
 
         mockMvc.perform(get(DrillController.ENDPOINT))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
-            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$.length()").value(2))
             .andExpect(jsonPath("$[0].id").value(DRILL_ID_1))
             .andExpect(jsonPath("$[0].name").value(DRILL_NAME_1))
             .andExpect(jsonPath("$[0].categories").isArray())
             .andExpect(jsonPath("$[0].categories.length()").value(1))
-            // For categories, we only want to return their ID, and NOTHING else
-            .andExpect(jsonPath("$[0].categories[0]").value(CATEGORY_ID_1))
-            .andExpect(jsonPath("$[0].categories[0].name").doesNotExist())
+            .andExpect(jsonPath("$[0].categories[0].id").value(CATEGORY_ID_1))
+            .andExpect(jsonPath("$[0].categories[0].name").value(CATEGORY_NAME_1))
             .andExpect(jsonPath("$[0].sub_categories").isArray())
             .andExpect(jsonPath("$[0].sub_categories.length()").value(1))
-            // For sub-categories, we only want to return their ID, and NOTHING else
-            .andExpect(jsonPath("$[0].sub_categories[0]").value(SUB_CATEGORY_ID_1))
-            .andExpect(jsonPath("$[0].sub_categories[0].name").doesNotExist())
+            .andExpect(jsonPath("$[0].sub_categories[0].id").value(SUB_CATEGORY_ID_1))
+            .andExpect(jsonPath("$[0].sub_categories[0].name").value(SUB_CATEGORY_NAME_1))
             .andExpect(jsonPath("$[0].related_drills").isArray())
             .andExpect(jsonPath("$[0].related_drills.length()").value(1))
-            // For related drills, we only want to return their ID, and NOTHING else
-            .andExpect(jsonPath("$[0].related_drills[0]").value(RELATED_DRILL_ID))
-            .andExpect(jsonPath("$[0].related_drills[0].name").doesNotExist())
+            .andExpect(jsonPath("$[0].related_drills[0].id").value(RELATED_DRILL_ID))
+            .andExpect(jsonPath("$[0].related_drills[0].name").value(RELATED_DRILL_NAME))
             .andExpect(jsonPath("$[0].instructions").isArray())
             .andExpect(jsonPath("$[0].instructions.length()").value(1));
+            // Drill at $[1] should be the related drill, don't have to go through it all again
     }
 
     @Test
@@ -399,6 +407,7 @@ public class DrillControllerTest {
         drill1.getInstructions().add(instructions1);
         when(categorySerivce.findAll(List.of(CATEGORY_ID_1))).thenReturn(List.of(category1));
         when(subCategorySerivce.findAll(List.of(SUB_CATEGORY_ID_1))).thenReturn(List.of(subCategory1));
+        when(drillService.findAll(List.of(RELATED_DRILL_ID))).thenReturn(List.of(relatedDrill));
         when(drillService.save(drill1)).thenReturn(drill1);
 
         mockMvc.perform(put(DrillController.ENDPOINT + "/id/" + DRILL_ID_1)
@@ -409,19 +418,16 @@ public class DrillControllerTest {
             .andExpect(jsonPath("$.name").value(DRILL_NAME_1))
             .andExpect(jsonPath("$.categories").isArray())
             .andExpect(jsonPath("$.categories.length()").value(1))
-            // For categories, we only want to return their ID, and NOTHING else
-            .andExpect(jsonPath("$.categories[0]").value(CATEGORY_ID_1))
-            .andExpect(jsonPath("$.categories[0].name").doesNotExist())
+            .andExpect(jsonPath("$.categories[0].id").value(CATEGORY_ID_1))
+            .andExpect(jsonPath("$.categories[0].name").value(CATEGORY_NAME_1))
             .andExpect(jsonPath("$.sub_categories").isArray())
             .andExpect(jsonPath("$.sub_categories.length()").value(1))
-            // For sub-categories, we only want to return their ID, and NOTHING else
-            .andExpect(jsonPath("$.sub_categories[0]").value(SUB_CATEGORY_ID_1))
-            .andExpect(jsonPath("$.sub_categories[0].name").doesNotExist())
+            .andExpect(jsonPath("$.sub_categories[0].id").value(SUB_CATEGORY_ID_1))
+            .andExpect(jsonPath("$.sub_categories[0].name").value(SUB_CATEGORY_NAME_1))
             .andExpect(jsonPath("$.related_drills").isArray())
             .andExpect(jsonPath("$.related_drills.length()").value(1))
-            // For related drills, we only want to return their ID, and NOTHING else
-            .andExpect(jsonPath("$.related_drills[0]").value(RELATED_DRILL_ID))
-            .andExpect(jsonPath("$.related_drills[0].name").doesNotExist())
+            .andExpect(jsonPath("$.related_drills[0].id").value(RELATED_DRILL_ID))
+            .andExpect(jsonPath("$.related_drills[0].name").value(RELATED_DRILL_NAME))
             .andExpect(jsonPath("$.instructions").isArray())
             .andExpect(jsonPath("$.instructions.length()").value(1));
 

--- a/src/test/java/com/damienwesterman/defensedrill/rest_api/unit/CategoriesServiceTest.java
+++ b/src/test/java/com/damienwesterman/defensedrill/rest_api/unit/CategoriesServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -139,6 +140,21 @@ public class CategoriesServiceTest {
         when(subCategoryRepo.findAll(any(Sort.class))).thenReturn(subCategoryList);
         assertEquals(subCategoryList, subCategoryService.findAll());
         verify(subCategoryRepo, times(1)).findAll(any(Sort.class));
+    }
+
+    @Test
+    public void test_findAll_byIds_callsCorrectRepoFind() {
+        List<CategoryEntity> categoryList = new ArrayList<>(List.of(categoryEntity));
+        List<Long> categoryIds = List.of(categoryEntity.getId());
+        when(categoryRepo.findAllById(categoryIds)).thenReturn(categoryList);
+        assertEquals(categoryList, categorySerivce.findAll(categoryIds));
+        verify(categoryRepo, times(1)).findAllById(categoryIds);
+
+        List<SubCategoryEntity> subCategoryList = new ArrayList<>(List.of(subCategoryEntity));
+        List<Long> subCategoryIds = List.of(subCategoryEntity.getId());
+        when(subCategoryRepo.findAllById(subCategoryIds)).thenReturn(subCategoryList);
+        assertEquals(subCategoryList, subCategoryService.findAll(subCategoryIds));
+        verify(subCategoryRepo, times(1)).findAllById(subCategoryIds);
     }
 
     @Test

--- a/src/test/java/com/damienwesterman/defensedrill/rest_api/unit/DrillServiceTest.java
+++ b/src/test/java/com/damienwesterman/defensedrill/rest_api/unit/DrillServiceTest.java
@@ -154,6 +154,15 @@ public class DrillServiceTest {
     }
 
     @Test
+    public void test_findAll_byIds_callsRepoFindAll() {
+        List<DrillEntity> drills = new ArrayList<>(List.of(drill));
+        List<Long> drillIds = List.of(drill.getId());
+        when(repo.findAllById(drillIds)).thenReturn(drills);
+        assertEquals(drills, service.findAll(drillIds));
+        verify(repo, times(1)).findAllById(drillIds);
+    }
+
+    @Test
     public void test_delete_callsDeleteById() {
         service.delete(0L);
         verify(repo, times(1)).deleteById(0L);


### PR DESCRIPTION
For ease of the front end and other consumers of the API, we will transfer more information along with the DrillResponseDTO. This will include the full CategoryEntity and SubCategoryEntity in the categories and subCategories lists. We also will implement a new simple DTO for related drills so the consumer does not have to make multiple requests to get the names of the related drills. Updated tests included.